### PR TITLE
Fix for upsert node not showing up in UI

### DIFF
--- a/coda-io-upsert.html
+++ b/coda-io-upsert.html
@@ -1,15 +1,14 @@
 <script type="text/javascript">
-    const pattern = /^[a-zA-Z0-9-_,\s]*$/;
     RED.nodes.registerType('coda-io-upsert',{
         category: 'function',
         color: '#f6e9de',
         defaults: {
             name: {value: ""},
-            coda_cnf_field_char_conv: {value: "", validate:RED.validators.regex(pattern)},
-            coda_cnf_field_num_val: {value: "", validate:RED.validators.regex(pattern)},
-            coda_cnf_field_no_conv: {value: "", validate:RED.validators.regex(pattern)},
+            coda_cnf_field_char_conv: {value: "", validate:RED.validators.regex(/^[a-zA-Z0-9-_,\s]*$/)},
+            coda_cnf_field_num_val: {value: "", validate:RED.validators.regex(/^[a-zA-Z0-9-_,\s]*$/)},
+            coda_cnf_field_no_conv: {value: "", validate:RED.validators.regex(/^[a-zA-Z0-9-_,\s]*$/)},
             null_val: {value: "[ empty ]"},
-            key_cols: {value: "", validate:RED.validators.regex(pattern)}
+            key_cols: {value: "", validate:RED.validators.regex(/^[a-zA-Z0-9-_,\s]*$/)}
         },
         inputs: 1,
         outputs: 1,

--- a/coda-io-upsert.js
+++ b/coda-io-upsert.js
@@ -1,8 +1,8 @@
 "use strict";
+
 module.exports = function(RED) {
 
     function codaIoUpsert(n) {
-
         RED.nodes.createNode(this, n);
         var node = this;
         node.on('input', function(msg) {


### PR DESCRIPTION
As mentioned in https://github.com/serene-water/node-red-contrib-coda-io/issues/4, the upsert node doesn't show up in the UI. With this change, I have verified that it shows in the UI and successfully upserts to a Coda table.