### PR TITLE
V1 api endpoint

### DIFF
--- a/core.js
+++ b/core.js
@@ -83,7 +83,7 @@ module.exports = class CodaReqestUrl {
             }
         }
         
-        return 'https://coda.io/apis/v1beta1/' + reqStr;
+        return 'https://coda.io/apis/v1/' + reqStr;
     }
 
     /**


### PR DESCRIPTION
I've tested this on the V1 endpoint. None of the implemented functionality has changed. All we need to do is update the endpoint and it works. 

At the moment, any site running on this version will have a growing number of random fails as Coda shuts the api down